### PR TITLE
Differentiate nitra results through exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nitra is a multi-process, optionally multi-server rspec and cucumber runner that
 ## Philosophy
 * Nitra attempts to do the simplest thing possible
 * Nitra (ab)uses unix primitives where possible
-* Nitra doesn't do thing that unix alnext_file does better (eg. rsync)
+* Nitra doesn't do things that unix already does better (eg. rsync)
 * IPC is accomplished via pipes and select
 * Forking is used heavily for several reasons
 * Running nitra locally should be easy

--- a/bin/nitra
+++ b/bin/nitra
@@ -8,5 +8,20 @@ Nitra::CommandLine.new(configuration, ARGV)
 if configuration.slave_mode
   Nitra::Slave::Server.new.run
 else
-  exit Nitra::Master.new(configuration, ARGV).run ? 0 : 1
+  result = Nitra::Master.new(configuration, ARGV).run
+
+  case result
+  when Nitra::Master::ABORTED
+    exit 1
+  when Nitra::Master::TEST_FAILURES
+    exit 2
+  when Nitra::Master::FAILURE
+    exit 3
+  when Nitra::Master::UNPROCESSED_FILES
+    exit 4
+  when Nitra::Master::SUCCESS
+    exit 0
+  else
+    exit 127
+  end
 end


### PR DESCRIPTION
This will allow determining whether there were only test failures or if
running the build actually failed itself.