### PR TITLE
Add experimental support for splitting rspec by examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- New option --split-rspec-files which supports splitting rspec tests. The existing --split-files
+               has been renamed to --split-cucumber-files, with the former now deprecated.
+- New option --split-rspec-files-regex which can be used in conjunction with --split-rspec-files.
+               This will restrict which rspec files will be split. If not set, all rspec files will
+               be split.
 
 ## [1.0.6] - 2018-11-30
 ### Added

--- a/lib/nitra/command_line.rb
+++ b/lib/nitra/command_line.rb
@@ -84,8 +84,24 @@ module Nitra
           configuration.add_slave connection_command
         end
 
-        opts.on("--split-files", "Split test files and run the scenarios in parallel") do
-          configuration.split_files = true
+        opts.on("--split-files", "Split cucumber files and run the scenarios in parallel (deprecated, use --split-cucumber-files)") do
+          configuration.split_cucumber_files = true
+        end
+
+        opts.on("--split-cucumber-files", "Split cucumber files and run the scenarios in parallel") do
+          configuration.split_cucumber_files = true
+        end
+
+        opts.on("--split-rspec-files", "Split rspec files and run the examples in parallel") do
+          configuration.split_rspec_files = true
+        end
+
+        opts.on("--split-rspec-files-regex PATTERN", "Regex to match against rspec filenames to determine whether they should be split. If not set, all specs will be split.") do |pattern|
+          if pattern[0] == '/' && pattern[-1] == '/'
+            configuration.split_rspec_files_regex = Regexp.new(pattern[1..-2])
+          else
+            configuration.split_rspec_files_regex = Regexp.new(Regexp.escape(pattern))
+          end
         end
 
         opts.on("--start-framework FRAMEWORK", String, "Start all workers with this framework first.  The default is to start a mixture of workers on each framework.") do |framework|

--- a/lib/nitra/configuration.rb
+++ b/lib/nitra/configuration.rb
@@ -2,7 +2,7 @@ require 'nitra/utils'
 
 module Nitra
   class Configuration
-    attr_accessor :debug, :quiet, :print_failures, :burndown_report, :rake_tasks, :split_files, :start_framework, :exceptions_to_retry, :tags_to_retry, :max_attempts
+    attr_accessor :debug, :quiet, :print_failures, :burndown_report, :rake_tasks, :split_cucumber_files, :split_rspec_files, :split_rspec_files_regex, :start_framework, :exceptions_to_retry, :tags_to_retry, :max_attempts
     attr_accessor :process_count, :environment, :slaves, :slave_mode, :frameworks
     attr_accessor :rspec_formatter, :rspec_out, :cucumber_formatter, :cucumber_out
 

--- a/lib/nitra/worker.rb
+++ b/lib/nitra/worker.rb
@@ -317,6 +317,10 @@ module Nitra
       def retry_attempts_remaining?
         @attempt && @attempt < @configuration.max_attempts
       end
+
+      def already_split?(filename)
+        filename.include?(':')
+      end
     end
   end
 end


### PR DESCRIPTION
This is fairly closely tied to internal rspec data-structures, but might
be useful for some legacy codebases with spec files with multiple
examples which are long running.