### PR TITLE
Revert rails connection handling monkey-patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+
+## [1.0.5] - 2018-11-08
 ### Added
 - Remove rails monkey patch initially added in `7a7e387`. This is causing breakage with tests using `fork` when using newer versions of mysql2. The connection sharing this monkey patch introduces causes connections to really be closed with newer versions of the gem. There seems to be no measurable performance difference without the monkey patch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Added
+- Remove rails monkey patch initially added in `7a7e387`. This is causing breakage with tests using `fork` when using newer versions of mysql2. The connection sharing this monkey patch introduces causes connections to really be closed with newer versions of the gem. There seems to be no measurable performance difference without the monkey patch.
+
 ## [1.0.4] - 2018-11-07
 ### Added
 - New option --retry-tags which allows retrying tests tagged with one of the configured tags.

--- a/lib/nitra/rails_tooling.rb
+++ b/lib/nitra/rails_tooling.rb
@@ -1,16 +1,3 @@
-require 'active_record'
-
-ActiveRecord::ConnectionAdapters::ConnectionHandler.class_eval do
-private
-  def owner_to_pool
-    @owner_to_pool[0] # instead of [Process.pid], which would change every time we fork for a new file
-  end
-
-  def class_to_pool
-    @class_to_pool[0] # instead of [Process.pid], which would change every time we fork for a new file
-  end
-end
-
 module Nitra
   class RailsTooling
     ##

--- a/nitra.gemspec
+++ b/nitra.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'nitra'
-  s.version = '1.0.4'
+  s.version = '1.0.5'
   s.platform = Gem::Platform::RUBY
   s.license = "MIT"
   s.homepage = "http://github.com/fluxfederation/nitra"

--- a/nitra.gemspec
+++ b/nitra.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'nitra'
-  s.version = '1.0.3'
+  s.version = '1.0.4'
   s.platform = Gem::Platform::RUBY
   s.license = "MIT"
   s.homepage = "http://github.com/fluxfederation/nitra"


### PR DESCRIPTION
Remove rails monkey patch initially added in `7a7e387`. This is causing breakage with newer tests using `fork` when using new versions of mysql2. The connection sharing this monkey patch introduces causes connections to really be closed with newer versions of the gem. There seems to be no measurable performance difference without the monkey patch.
