### PR TITLE
Display the error when a test is re-run

### DIFF
--- a/lib/nitra/master.rb
+++ b/lib/nitra/master.rb
@@ -164,7 +164,7 @@ protected
         end
 
       when "retry"
-        say_lines(data["text"], "#{data["on"]} [RETRY-#{data["attempt"]} for #{data["filename"]}] ")
+        say_lines(data["text"], "#{data["on"]} [RETRY-#{data["retry_attempt"]} for #{data["filename"]}] ")
         burndown.retry(data["on"], data["framework"], data["filename"])
         say "#{data["on"]} Re-running #{data["filename"]}"
 

--- a/lib/nitra/master.rb
+++ b/lib/nitra/master.rb
@@ -164,6 +164,7 @@ protected
         end
 
       when "retry"
+        say_lines(data["text"], "#{data["on"]} [RETRY-#{data["attempt"]} for #{data["filename"]}] ")
         burndown.retry(data["on"], data["framework"], data["filename"])
         say "#{data["on"]} Re-running #{data["filename"]}"
 

--- a/lib/nitra/worker.rb
+++ b/lib/nitra/worker.rb
@@ -225,15 +225,16 @@ module Nitra
         })
 
       rescue RetryException
+        retry_attempt = @attempt
         @attempt += 1
         channel.write({
-          "command"   => "retry",
-          "framework" => self.class.framework_name,
-          "filename"  => filename,
-          "on"        => on,
-          "failure"   => true,
-          "text"      => io.string,
-          "attempt"   => @attempt
+          "command"         => "retry",
+          "framework"       => self.class.framework_name,
+          "filename"        => filename,
+          "on"              => on,
+          "failure"         => true,
+          "text"            => io.string,
+          "retry_attempt"   => retry_attempt
         })
         clean_up
         retry

--- a/lib/nitra/worker.rb
+++ b/lib/nitra/worker.rb
@@ -92,7 +92,7 @@ module Nitra
         end
         trap("SIGINT") do
           channel.write("command" => "error", "process" => "trap", "text" => 'Received SIGINT', "on" => on)
-          Process.kill("SIGKILL", Process.pid) 
+          Process.kill("SIGKILL", Process.pid)
         end
 
         channel.write("command" => "starting", "framework" => self.class.framework_name, "on" => on)
@@ -226,13 +226,16 @@ module Nitra
 
       rescue RetryException
         @attempt += 1
-        clean_up
         channel.write({
           "command"   => "retry",
           "framework" => self.class.framework_name,
           "filename"  => filename,
           "on"        => on,
+          "failure"   => true,
+          "text"      => io.string,
+          "attempt"   => @attempt
         })
+        clean_up
         retry
 
       rescue LoadError, Exception => e


### PR DESCRIPTION
Displays the error from the test framework when a test is run. Currently, when a test re-runs and successfully passes, the error of the failed test is not displayed. Showing such errors can be useful to determine the cause of intermittent failures for flaky tests. 