### PR TITLE
PDT-1622 Use upstream-RSpec API for cleaning up global configuration

### DIFF
--- a/lib/nitra/workers/rspec.rb
+++ b/lib/nitra/workers/rspec.rb
@@ -99,13 +99,8 @@ module Nitra::Workers
       # Rspec.reset in 2.6 didn't destroy your rspec_rails fixture loading, we can't use it anymore for it's intended purpose.
       # This means our world object will be slightly polluted by the preload_framework code, but that's a small price to pay
       # to upgrade.
-      #
-      # RSpec.reset
-      #
-      RSpec.instance_variable_set(:@world, nil)
 
-      # reset the reporter so we don't end up with two when we reuse the Configuration
-      RSpec.configuration.reset
+      RSpec.clear_examples
     end
 
     def runnable_parts(runner)


### PR DESCRIPTION
In this past, we would manually unset the '@world' so that RSpec would
then rebuild a completely fresh execution context.

Problem is, this gives us an entirely fresh execution context, with all
shared example groups unloaded after the first test execution.

Rather than clearing the entire World, use the RSpec.clear_examples
method, which does everything we need, without throwing out all shared
examples.

This is required in order to include shared examples from an external Ruby Gem.

Inspired by:

  - https://github.com/rspec/rspec-core/issues/1700
  - https://github.com/waterlink/rspec-core/commit/e49454ee6f9e1551e4fcf3c3664bdb725e3e658c