### PR TITLE
RSpec recommends not using global DSL for its keywords

### DIFF
--- a/lib/nitra/workers/rspec.rb
+++ b/lib/nitra/workers/rspec.rb
@@ -19,7 +19,7 @@ module Nitra::Workers
     def minimal_file
       <<-EOS
       require 'spec_helper'
-      describe('nitra preloading') do
+      RSpec.describe('nitra preloading') do
         it('preloads the fixtures') do
           expect(1).to eq(1)
         end

--- a/nitra.gemspec
+++ b/nitra.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'nitra'
-  s.version = '1.0.12'
+  s.version = '1.0.13'
   s.platform = Gem::Platform::RUBY
   s.license = "MIT"
   s.homepage = "http://github.com/fluxfederation/nitra"


### PR DESCRIPTION
In the PS main repo, we're disabling RSpec DSL in the global context. This means we have to qualify top level RSpec tests.