### PR TITLE
Proactively sort splittable specs to be processed first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Updated
+- Proactively sort splittable rspec files so all splittable files are processed first
+
 ## [1.0.15] - 2020-04-07
 ### Updated
 - Support parsing results when using the --retry flag with cucumber

--- a/lib/nitra/master.rb
+++ b/lib/nitra/master.rb
@@ -110,7 +110,7 @@ protected
 
   def load_files_from_framework_list
     @files_by_framework = configuration.frameworks.inject({}) do |result, (framework_name, framework_patterns)|
-      files = Nitra::Workers::Worker.worker_classes[framework_name].files(framework_patterns)
+      files = Nitra::Workers::Worker.worker_classes[framework_name].files(configuration, framework_patterns)
       result[framework_name] = files unless files.empty?
       result
     end

--- a/lib/nitra/worker.rb
+++ b/lib/nitra/worker.rb
@@ -23,7 +23,7 @@ module Nitra
           self.name.split("::").last.downcase
         end
 
-        def files(patterns)
+        def files(configuration, patterns)
           Dir[*patterns].sort_by {|f| File.size(f)}.reverse
         end
       end

--- a/lib/nitra/workers/rspec.rb
+++ b/lib/nitra/workers/rspec.rb
@@ -27,6 +27,18 @@ module Nitra::Workers
       EOS
     end
 
+    # sort spec files so splittable files get split first
+    def files(configuration, patterns)
+      sorted_files = super(configuration, patterns)
+
+      return sorted_files unless configuration.split_rspec_files
+
+      # [[splittable_file], [not_splittable_file]].flatten
+      sorted_files.partition do |file|
+        configuration.split_rspec_files_regex && file.name =~ configuration.split_rspec_files_regex
+      end.flatten
+    end
+
     ##
     # Run an rspec file.
     #


### PR DESCRIPTION
These should theoretically be fast to run and are better suited to
padding out the end of a worker, so make sure we run through and split
all specs which can be split first, then carry on processing normal
specs, followed by the already split ones.